### PR TITLE
Pin pypa/gh-action-pypi-publish to release/v1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,6 @@ jobs:
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## What

Pin the PyPI publish action from the sunset `@master` branch to the maintained `@release/v1`.

## Why

The `master` branch of `pypa/gh-action-pypi-publish` has been sunset. 