### PR TITLE
Send Origin header on simulator OAuth grant request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = ["version"]
 dev = [
     "pre-commit>=3.6.2",
     "pytest>=7.2.1",
-    "pytest-asyncio>=0.20.3",
+    "pytest-asyncio>=0.20.3,<0.24",
     "pytest-mock>=3.10.0",
     "pytest-postgresql>=5.0.0",
 ]

--- a/src/homeconnect_watcher/client/client.py
+++ b/src/homeconnect_watcher/client/client.py
@@ -270,6 +270,9 @@ class HomeConnectSimulationClient(HomeConnectClient):
                 "WineCooler WineCooler-Control WineCooler-Monitor WineCooler-Settings",
                 "redirect_uri": environ["HOMECONNECT_REDIRECT_URI"],
             },
+            # The simulator's grant endpoint rejects requests without a matching Origin header,
+            # returning a 500 instead of the redirect that carries the authorization code.
+            headers={"Origin": "https://simulator.home-connect.com"},
             allow_redirects=False,
         )
         response = session.get(response.headers["Location"], allow_redirects=False)


### PR DESCRIPTION
The simulator's OAuth grant endpoint now returns a 500 unless an `Origin` header is present, which broke `HomeConnectSimulationClient.authenticate()` and the live-simulator tests. Adds the header to the grant request.