### PR TITLE
Drop custom event_loop fixture and unpin pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = ["version"]
 dev = [
     "pre-commit>=3.6.2",
     "pytest>=7.2.1",
-    "pytest-asyncio>=0.20.3,<0.24",
+    "pytest-asyncio>=1.0",
     "pytest-mock>=3.10.0",
     "pytest-postgresql>=5.0.0",
 ]
@@ -39,6 +39,11 @@ prometheus = ["prometheus-client>=0.16.0"]
 
 [project.scripts]
 homeconnect-watcher = "homeconnect_watcher.cli:app"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
+markers = ["events: preload the database with the given events"]
 
 [tool.setuptools_scm]
 version_file = "src/homeconnect_watcher/_version.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from asyncio import get_event_loop
-
 from dotenv import load_dotenv
 from pytest import fixture
 from pytest_asyncio import fixture as async_fixture
@@ -13,13 +11,6 @@ from homeconnect_watcher.event import HomeConnectEvent
 @fixture(scope="session", autouse=True)
 def dotenv():
     load_dotenv()
-
-
-@fixture(scope="session")
-def event_loop():
-    loop = get_event_loop()
-    yield loop
-    loop.close()
 
 
 @async_fixture(scope="session")


### PR DESCRIPTION
- Remove the session-scoped `event_loop` fixture; configure session loop scope via `[tool.pytest.ini_options]` instead
- Unpin `pytest-asyncio` (now `>=1.0`), letting pytest float to 9.x
- Register the `events` marker