### PR TITLE
Harden workflows, refresh tooling, adopt ty

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,14 +7,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      HOMECONNECT_CLIENT_ID: ${{ vars.HOMECONNECT_CLIENT_ID }}
-      HOMECONNECT_CLIENT_SECRET: ${{ secrets.HOMECONNECT_CLIENT_SECRET }}
-      HOMECONNECT_REDIRECT_URI: ${{ vars.HOMECONNECT_REDIRECT_URI }}
 
     steps:
       - uses: actions/checkout@v4
@@ -32,4 +31,8 @@ jobs:
         run: pre-commit run --all-files
 
       - name: Run Pytest
+        env:
+          HOMECONNECT_CLIENT_ID: ${{ vars.HOMECONNECT_CLIENT_ID }}
+          HOMECONNECT_CLIENT_SECRET: ${{ secrets.HOMECONNECT_CLIENT_SECRET }}
+          HOMECONNECT_REDIRECT_URI: ${{ vars.HOMECONNECT_REDIRECT_URI }}
         run: pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Run Pre-Commit
         run: pre-commit run --all-files
 
+      - name: Run ty
+        run: ty check
+
       - name: Run Pytest
         env:
           HOMECONNECT_CLIENT_ID: ${{ vars.HOMECONNECT_CLIENT_ID }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,26 +7,49 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
 
-      - name: Install Dependencies
+      - name: Build
         run: |
           pip3 install build
           python3 -m build
 
-      - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          name: dist
+          path: dist/
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags')
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,9 +13,9 @@ repos:
       - id: pretty-format-json
         args: [--autofix]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5
+    rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56  # v0.15.20
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Earlier releases (0.0.13 and before) are documented only in the git history.
+
+## [Unreleased]
+
+### Added
+
+- CI now tests Python 3.10 through 3.13 and runs the `ty` type checker.
+- This changelog.
+
+### Changed
+
+- `load`, `views` and `refresh-view` now require `--db-uri` (and `load` also `--log-path`), reporting a clear error when missing instead of crashing.
+- Releases are published to PyPI via Trusted Publishing.
+
+### Fixed
+
+- Simulator authentication works again: the OAuth grant request now sends the `Origin` header the simulator requires.
+- A missing view name in a SQL view definition now raises a descriptive `ValueError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest-asyncio>=1.0",
     "pytest-mock>=3.10.0",
     "pytest-postgresql>=5.0.0",
+    "ty",
 ]
 prometheus = ["prometheus-client>=0.16.0"]
 
@@ -47,6 +48,9 @@ markers = ["events: preload the database with the given events"]
 
 [tool.setuptools_scm]
 version_file = "src/homeconnect_watcher/_version.py"
+
+[tool.ty.src]
+include = ["src"]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ version_file = "src/homeconnect_watcher/_version.py"
 
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/src/homeconnect_watcher/cli.py
+++ b/src/homeconnect_watcher/cli.py
@@ -9,9 +9,10 @@ from typer import Option, Typer
 from uvicorn import run
 
 from homeconnect_watcher.api import loop
-from homeconnect_watcher.client.client import HomeConnectSimulationClient, HomeConnectClient
+from homeconnect_watcher.client.client import HomeConnectClient, HomeConnectSimulationClient
 from homeconnect_watcher.db import WatcherDBClient
 from homeconnect_watcher.db.utils import clean_schema
+from homeconnect_watcher.exporter.base import BaseExporter
 from homeconnect_watcher.exporter.file import FileExporter
 from homeconnect_watcher.exporter.postgres import PGExporter
 from homeconnect_watcher.read import read_events
@@ -53,7 +54,7 @@ def watch(
     initialize_logging(level=log_level)
     metrics = Metrics(port=metrics_port) if metrics_port else None
     client = (HomeConnectSimulationClient if simulation else HomeConnectClient)(metrics=metrics)
-    exporters = []
+    exporters: list[BaseExporter] = []
     if log_path is not None:
         exporters.append(FileExporter(path=Path(log_path), flush_interval=timedelta(seconds=flush_interval)))
     if db_uri is not None:
@@ -63,8 +64,8 @@ def watch(
 
 @app.command()
 def load(
-    db_uri: Annotated[Optional[str], Option(envvar="HCW_DB_URI")] = None,
-    log_path: Annotated[Optional[str], Option(envvar="HOMECONNECT_PATH")] = None,
+    db_uri: Annotated[str, Option(envvar="HCW_DB_URI")],
+    log_path: Annotated[str, Option(envvar="HOMECONNECT_PATH")],
     clean: bool = False,
 ):
     exporter = PGExporter(connection_string=db_uri)
@@ -81,7 +82,7 @@ def load(
 
 
 @app.command()
-def views(db_uri: Annotated[Optional[str], Option(envvar="HCW_DB_URI")] = None, drop: bool = False):
+def views(db_uri: Annotated[str, Option(envvar="HCW_DB_URI")], drop: bool = False):
     with WatcherDBClient(connection_string=db_uri, init=False) as client:
         with client.connection.transaction():
             if drop:
@@ -90,6 +91,6 @@ def views(db_uri: Annotated[Optional[str], Option(envvar="HCW_DB_URI")] = None, 
 
 
 @app.command()
-def refresh_view(db_uri: Annotated[Optional[str], Option(envvar="HCW_DB_URI")] = None):
+def refresh_view(db_uri: Annotated[str, Option(envvar="HCW_DB_URI")]):
     with WatcherDBClient(connection_string=db_uri) as client:
         client.refresh_views()

--- a/src/homeconnect_watcher/client/client.py
+++ b/src/homeconnect_watcher/client/client.py
@@ -1,22 +1,21 @@
 from asyncio import sleep
-from json import load, dump
+from json import dump, load
 from logging import getLogger
 from os import environ
 from pathlib import Path
 from re import search
 from time import monotonic
-from typing import AsyncIterable
+from typing import Any, AsyncIterable
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.oauth2.rfc6749.wrappers import OAuth2Token
+from httpx import ReadTimeout, RemoteProtocolError, StreamError
 from requests import Session
-from httpx import StreamError, ReadTimeout, RemoteProtocolError
-
 
 from homeconnect_watcher.client.appliance import HomeConnectAppliance
-from homeconnect_watcher.trigger import Trigger
 from homeconnect_watcher.event import HomeConnectEvent
-from homeconnect_watcher.exceptions import HomeConnectRequestError, HomeConnectConnectionClosed, HomeConnectTimeout
+from homeconnect_watcher.exceptions import HomeConnectConnectionClosed, HomeConnectRequestError, HomeConnectTimeout
+from homeconnect_watcher.trigger import Trigger
 from homeconnect_watcher.utils import Metrics, retry, timeout
 
 
@@ -38,9 +37,9 @@ class HomeConnectClient:
             token_endpoint=self._token_endpoint,
             token=self._load_token(),
         )
-        self.client.auth = self.client.token_auth  # Ensure we use token auth for all requests.
+        self.client.auth = self.client.token_auth  # ty: ignore[invalid-assignment]  # Ensure token auth everywhere.
         self._appliances: list["HomeConnectAppliance"] | None = None
-        self._last_event: int | None = None
+        self._last_event: float | None = None
         self.metrics = metrics
         if self.metrics:
             self.metrics.set_last_event(lambda: monotonic() - self._last_event if self._last_event else -1)
@@ -224,7 +223,7 @@ class HomeConnectClient:
             dump(token, token_file)
 
     @retry(n_tries=3, exceptions=(ReadTimeout,))
-    async def _get(self, path: str) -> dict[str, ...]:
+    async def _get(self, path: str) -> dict[str, Any]:
         await sleep(delay=1.5)  # Rate limit
         resp = await self.client.get(f"{self._appliances_endpoint}{path}")
         data = resp.json()

--- a/src/homeconnect_watcher/db/client.py
+++ b/src/homeconnect_watcher/db/client.py
@@ -1,19 +1,21 @@
 from json import dumps
 from logging import getLogger
 
-from psycopg import Connection, Cursor, connect
+from psycopg import Connection, Cursor, connect, sql
 
-from .view import load_views
 from ..event import HomeConnectEvent
+from .view import load_views
 
 logger = getLogger(__name__)
 
 
 class WatcherDBClient:
+    # Set in __enter__; only valid inside the context.
+    connection: Connection
+    cursor: Cursor
+
     def __init__(self, connection_string: str, init: bool = True):
         self.connection_string = connection_string
-        self.connection: Connection | None = None
-        self.cursor: Cursor | None = None
         self.init = init
 
     def __enter__(self) -> "WatcherDBClient":
@@ -27,9 +29,9 @@ class WatcherDBClient:
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.cursor.close()
-        self.cursor = None
+        del self.cursor
         self.connection.close()
-        self.connection = None
+        del self.connection
         logger.info("Database connection closed.")
         return
 
@@ -37,6 +39,7 @@ class WatcherDBClient:
     def event_count(self) -> int:
         self.cursor.execute("SELECT COUNT(*) AS cnt FROM events")
         result = self.cursor.fetchone()
+        assert result is not None  # COUNT(*) always returns a row.
         return result[0]
 
     def create_table(self) -> None:
@@ -57,20 +60,20 @@ CREATE TABLE IF NOT EXISTS events (
         logger.info("Creating events table.")
         with self.connection.transaction():
             for view in load_views():
-                self.connection.execute(view.query)
+                self.connection.execute(view.query)  # ty: ignore[no-matching-overload]  # trusted packaged SQL
 
     def drop_views(self) -> None:
         logger.info("Dropping views.")
         with self.connection.transaction():
             for view in reversed(load_views()):
-                self.connection.execute(view.drop_query)
+                self.connection.execute(view.drop_query)  # ty: ignore[no-matching-overload]  # trusted packaged SQL
 
     def refresh_views(self) -> None:
         logger.info("Creating views.")
         with self.connection.transaction():
             for view in load_views():
                 if view.materialized:
-                    self.connection.execute(f"REFRESH MATERIALIZED VIEW {view.name};")
+                    self.connection.execute(sql.SQL("REFRESH MATERIALIZED VIEW {};").format(sql.Identifier(view.name)))
 
     def write_events(self, events: list[HomeConnectEvent]) -> None:
         data = [(event.appliance_id or "", event.event, event.datetime, dumps(event.items)) for event in events]

--- a/src/homeconnect_watcher/db/utils.py
+++ b/src/homeconnect_watcher/db/utils.py
@@ -1,7 +1,11 @@
-from psycopg import Connection
+from psycopg import Connection, sql
 
 
 def clean_schema(connection: Connection) -> None:
     with connection.cursor() as cursor:
         db_name = connection.info.dbname
-        cursor.execute(f"DROP SCHEMA IF EXISTS {db_name} CASCADE; CREATE SCHEMA {db_name};")
+        cursor.execute(
+            sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE; CREATE SCHEMA {};").format(
+                sql.Identifier(db_name), sql.Identifier(db_name)
+            )
+        )

--- a/src/homeconnect_watcher/db/view.py
+++ b/src/homeconnect_watcher/db/view.py
@@ -17,6 +17,8 @@ class View:
     @property
     def name(self) -> str:
         result = search("VIEW(?: IF NOT EXISTS)? ([a-z_]+) AS", self.query, IGNORECASE)
+        if result is None:
+            raise ValueError(f"Cannot determine view name from query: {self.query[:80]!r}")
         return result.group(1)
 
 

--- a/src/homeconnect_watcher/event.py
+++ b/src/homeconnect_watcher/event.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from json import dumps, loads
 from time import time
+from typing import Any
 
 from homeconnect_watcher.trigger import Trigger
 
@@ -11,15 +12,15 @@ class HomeConnectEvent:
     event: str
     timestamp: float
     appliance_id: str | None = None
-    data: dict[str, ...] | None = None
-    error: dict[str, ...] | None = None
+    data: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
 
     @property
     def datetime(self) -> datetime:
         return datetime.fromtimestamp(self.timestamp).astimezone()
 
     @classmethod
-    def from_request(cls, request: str, appliance_id: str, response: dict[str, ...]) -> "HomeConnectEvent":
+    def from_request(cls, request: str, appliance_id: str, response: dict[str, Any]) -> "HomeConnectEvent":
         if "error" in response:
             error = response["error"]
             data = None
@@ -36,7 +37,7 @@ class HomeConnectEvent:
 
     @classmethod
     def from_stream(cls, stream: bytes) -> "HomeConnectEvent":
-        data = {"timestamp": time()}
+        data: dict[str, Any] = {"timestamp": time()}
         for line in stream.decode("utf-8").split("\n"):
             if line.startswith("data:") and len(line) > 5:
                 data["data"] = loads(line[5:])
@@ -69,6 +70,7 @@ class HomeConnectEvent:
             ):
                 return {"BSH.Common.Root.ActiveProgram": None}
             else:
+                assert self.data is not None
                 result = {item["key"]: item["value"] for item in self.data["options"]}
                 result["BSH.Common.Root.ActiveProgram"] = self.data["key"]
                 return result
@@ -79,14 +81,17 @@ class HomeConnectEvent:
             ):
                 return {"BSH.Common.Root.SelectedProgram": None}
             else:
+                assert self.data is not None
                 result = {item["key"]: item["value"] for item in self.data["options"]}
                 result["BSH.Common.Root.SelectedProgram"] = self.data["key"]
                 return result
         elif self.error is not None:
             return {}
         elif self.event == "STATUS-REQUEST":
+            assert self.data is not None
             return {entry["key"]: entry["value"] for entry in self.data["status"]}
         elif self.event == "SETTINGS-REQUEST":
+            assert self.data is not None
             return {entry["key"]: entry["value"] for entry in self.data["settings"]}
         elif self.event in ("CONNECTED", "DISCONNECTED"):
             if self.data is not None and "key" in self.data:
@@ -105,7 +110,7 @@ class HomeConnectEvent:
         return None
 
     def __str__(self) -> str:
-        data = dict(appliance_id=self.appliance_id, event=self.event, timestamp=self.timestamp)
+        data: dict[str, Any] = dict(appliance_id=self.appliance_id, event=self.event, timestamp=self.timestamp)
         if self.data:
             data["data"] = self.data
         if self.error:
@@ -115,14 +120,17 @@ class HomeConnectEvent:
     @property
     def trigger(self) -> Trigger | None:
         if self.event in ("CONNECTED", "PAIRED"):
+            assert self.appliance_id is not None
             # For any new(ly connected) appliance, we perform all requests.
             return Trigger(
                 appliance_id=self.appliance_id, status=True, settings=True, selected_program=True, active_program=True
             )
         elif self.event in ("NOTIFY", "EVENT"):
+            assert self.appliance_id is not None
             # For any appliance that is active, request the status once in a while.
             return Trigger(appliance_id=self.appliance_id, status=True, interval=True)
         elif self.event == "STATUS":
+            assert self.appliance_id is not None
             # For an appliance that just switched to running, get the program.
             if self.items.get("BSH.Common.Status.OperationState", "") == "BSH.Common.EnumType.OperationState.Run":
                 return Trigger(appliance_id=self.appliance_id, active_program=True, settings=True)

--- a/src/homeconnect_watcher/exporter/base.py
+++ b/src/homeconnect_watcher/exporter/base.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from logging import getLogger
 
-
 from homeconnect_watcher.event import HomeConnectEvent
 
 

--- a/src/homeconnect_watcher/exporter/file.py
+++ b/src/homeconnect_watcher/exporter/file.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional, TextIO
+from typing import TextIO
 
 from homeconnect_watcher.event import HomeConnectEvent
 
@@ -8,11 +8,13 @@ from .base import BaseExporter
 
 
 class FileExporter(BaseExporter):
+    # Set in __enter__; only valid inside the context.
+    _fp: TextIO
+
     def __init__(self, path: Path, flush_interval: timedelta = timedelta(minutes=30)):
         super().__init__()
         self.path = path
         self.flush_interval = flush_interval
-        self._fp: Optional[TextIO] = None
         self._last_flush: datetime = datetime.now()
 
     def __enter__(self) -> "FileExporter":
@@ -21,7 +23,7 @@ class FileExporter(BaseExporter):
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self._fp.close()
-        self._fp = None
+        del self._fp
         return
 
     def export(self, event: HomeConnectEvent) -> None:

--- a/src/homeconnect_watcher/exporter/postgres.py
+++ b/src/homeconnect_watcher/exporter/postgres.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 
+from homeconnect_watcher.db import WatcherDBClient
 from homeconnect_watcher.event import HomeConnectEvent
 from homeconnect_watcher.exporter import BaseExporter
-from homeconnect_watcher.db import WatcherDBClient
 
 
 class PGExporter(BaseExporter, WatcherDBClient):

--- a/src/homeconnect_watcher/utils/logging.py
+++ b/src/homeconnect_watcher/utils/logging.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from logging import basicConfig, DEBUG, INFO, WARNING
+from logging import DEBUG, INFO, WARNING, basicConfig
 
 
 class LogLevel(str, Enum):
@@ -9,5 +9,5 @@ class LogLevel(str, Enum):
 
 
 def initialize_logging(level: LogLevel) -> None:
-    level = WARNING if level == LogLevel.WARNING else INFO if level == LogLevel.INFO else DEBUG
-    basicConfig(level=level, format="%(asctime)s %(name)s - %(levelname)s:%(message)s")
+    numeric_level = WARNING if level == LogLevel.WARNING else INFO if level == LogLevel.INFO else DEBUG
+    basicConfig(level=numeric_level, format="%(asctime)s %(name)s - %(levelname)s:%(message)s")

--- a/src/homeconnect_watcher/utils/metrics.py
+++ b/src/homeconnect_watcher/utils/metrics.py
@@ -2,7 +2,6 @@ from logging import getLogger
 from time import monotonic
 from typing import Callable
 
-
 from homeconnect_watcher._version import __version__
 from homeconnect_watcher.event import HomeConnectEvent
 
@@ -25,7 +24,7 @@ class Metrics:
     def __init__(self, port: int):
         self.logger = getLogger(self.__class__.__name__)
         try:
-            from prometheus_client import Counter, Gauge, Info, start_http_server
+            from prometheus_client import Counter, Gauge, Info, start_http_server  # ty: ignore[unresolved-import]
         except ImportError:
             self.logger.error("Unable to expose prometheus metrics; prometheus_client is not installed.")
             self.logger.error(

--- a/src/homeconnect_watcher/utils/retry.py
+++ b/src/homeconnect_watcher/utils/retry.py
@@ -1,23 +1,26 @@
 from asyncio import sleep
 from logging import getLogger
-from typing import Any, Callable, Type, TypeVar
+from typing import Awaitable, Callable, ParamSpec, TypeVar
 
 logger = getLogger(__name__)
-F = TypeVar(name="F", bound=Callable[..., Any])
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
-def retry(n_tries: int, delay: float = 1, exceptions: Type[Exception] | tuple[Type[Exception]] = Exception):
-    def func_wrapper(f: F) -> F:
-        async def wrapper(*args, **kwargs):
+def retry(n_tries: int, delay: float = 1, exceptions: type[Exception] | tuple[type[Exception], ...] = Exception):
+    def func_wrapper(f: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             for i_try in range(n_tries):
                 try:
                     return await f(*args, **kwargs)
                 except exceptions as exc:
-                    logger.debug(f"Function {f.__name__} failed with exception {exc} in try {i_try} out of {n_tries}.")
+                    name = getattr(f, "__name__", repr(f))
+                    logger.debug(f"Function {name} failed with exception {exc} in try {i_try} out of {n_tries}.")
                     if i_try + 1 == n_tries:
                         raise exc
                     else:
                         await sleep(delay)
+            raise RuntimeError(f"retry requires n_tries >= 1, got {n_tries}.")
 
         return wrapper
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from dotenv import load_dotenv
 from pytest import fixture
 from pytest_asyncio import fixture as async_fixture
 
-from homeconnect_watcher.client import HomeConnectClient, HomeConnectAppliance
+from homeconnect_watcher.client import HomeConnectAppliance, HomeConnectClient
 from homeconnect_watcher.client.client import HomeConnectSimulationClient
 from homeconnect_watcher.db import WatcherDBClient
 from homeconnect_watcher.event import HomeConnectEvent

--- a/tests/db/views/test_view_events.py
+++ b/tests/db/views/test_view_events.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from pytest import mark
 from zoneinfo import ZoneInfo
+
+from pytest import mark
 
 from homeconnect_watcher.db import WatcherDBClient
 

--- a/tests/db/views/test_view_session.py
+++ b/tests/db/views/test_view_session.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from pytest import mark
 from zoneinfo import ZoneInfo
+
+from pytest import mark
 
 from homeconnect_watcher.db import WatcherDBClient
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,8 +1,8 @@
 from pytest import mark, skip
 
 from homeconnect_watcher.client import HomeConnectAppliance
-from homeconnect_watcher.trigger import Trigger
 from homeconnect_watcher.event import HomeConnectEvent
+from homeconnect_watcher.trigger import Trigger
 
 
 class TestFromStream:


### PR DESCRIPTION
- Publish via PyPI Trusted Publishing (OIDC) from a `pypi` environment; least-privilege `permissions` on both workflows; simulator secret scoped to the pytest step
- Current ruff with import sorting; pre-commit hooks and actions pinned by SHA; CI matrix Python 3.10–3.13; dependabot for pip and github-actions
- Adopt `ty` (checks `src/`) and fix its findings
- Add a changelog